### PR TITLE
[JENKINS-66312] Prepare SCM HttpClient for core Guava upgrade

### DIFF
--- a/src/main/java/com/meowlomo/jenkins/scm_httpclient/HttpRequestExcution.java
+++ b/src/main/java/com/meowlomo/jenkins/scm_httpclient/HttpRequestExcution.java
@@ -154,11 +154,11 @@ public class HttpRequestExcution {
 		List<IntStream> ranges = DescriptorImpl.parseToRange(validResponseCodes);
 		for (IntStream range : ranges) {
 			if (range.anyMatch(status -> status == response.getStatus())) {
-				localLogger.println("Success code from " + range);
+				localLogger.println("Success: Status code " + response.getStatus() + " is in the accepted range: " + validResponseCodes);
 				return;
 			}
 		}
 		throw new AbortException(
-				"Fail: the returned code " + response.getStatus() + " is not in the accepted range: " + validResponseCodes);
+				"Fail: Status code " + response.getStatus() + " is not in the accepted range: " + validResponseCodes);
 	}
 }

--- a/src/main/java/com/meowlomo/jenkins/scm_httpclient/HttpRequestExcution.java
+++ b/src/main/java/com/meowlomo/jenkins/scm_httpclient/HttpRequestExcution.java
@@ -9,6 +9,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -17,7 +18,6 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 
-import com.google.common.collect.Range;
 import com.meowlomo.jenkins.scm_httpclient.ScmHttpClient.DescriptorImpl;
 import com.meowlomo.jenkins.scm_httpclient.constant.HttpMode;
 import com.meowlomo.jenkins.scm_httpclient.constant.MimeType;
@@ -151,14 +151,14 @@ public class HttpRequestExcution {
 	}
 
 	private void responseCodeIsValid(ResponseContentSupplier response) throws AbortException {
-		List<Range<Integer>> ranges = DescriptorImpl.parseToRange(validResponseCodes);
-		for (Range<Integer> range : ranges) {
-			if (range.contains(response.getStatus())) {
+		List<IntStream> ranges = DescriptorImpl.parseToRange(validResponseCodes);
+		for (IntStream range : ranges) {
+			if (range.anyMatch(status -> status == response.getStatus())) {
 				localLogger.println("Success code from " + range);
 				return;
 			}
 		}
 		throw new AbortException(
-				"Fail: the returned code " + response.getStatus() + " is not in the accepted range: " + ranges);
+				"Fail: the returned code " + response.getStatus() + " is not in the accepted range: " + validResponseCodes);
 	}
 }

--- a/src/main/java/com/meowlomo/jenkins/scm_httpclient/model/ResponseContentSupplier.java
+++ b/src/main/java/com/meowlomo/jenkins/scm_httpclient/model/ResponseContentSupplier.java
@@ -10,14 +10,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
-
-import com.google.common.base.Strings;
-import com.google.common.io.ByteStreams;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -52,9 +50,9 @@ public class ResponseContentSupplier implements Serializable, AutoCloseable {
 			InputStream entityContent = entity != null ? entity.getContent() : null;
 
 			if (entityContent != null) {
-				byte[] bytes = ByteStreams.toByteArray(entityContent);
+				byte[] bytes = IOUtils.toByteArray(entityContent);
 				contentStream = new ByteArrayInputStream(bytes);
-				content = new String(bytes, Strings.isNullOrEmpty(charset) ? Charset.defaultCharset().name() : charset);
+				content = new String(bytes, charset == null || charset.isEmpty() ? Charset.defaultCharset().name() : charset);
 			}
 //			else {
 //				contentStream = entityContent;

--- a/src/main/java/com/meowlomo/jenkins/scm_httpclient/util/HttpClientUtil.java
+++ b/src/main/java/com/meowlomo/jenkins/scm_httpclient/util/HttpClientUtil.java
@@ -24,7 +24,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.protocol.HttpContext;
 
-import com.google.common.base.Strings;
 import com.meowlomo.jenkins.scm_httpclient.constant.HttpMode;
 
 public class HttpClientUtil {
@@ -67,7 +66,7 @@ public class HttpClientUtil {
 
 	private HttpEntity makeEntity(RequestAction requestAction) throws
 			UnsupportedEncodingException {
-		if (!Strings.isNullOrEmpty(requestAction.getRequestBody())) {
+		if (requestAction.getRequestBody() != null && !requestAction.getRequestBody().isEmpty()) {
 			ContentType contentType = null;
 			for (HttpRequestNameValuePair header : requestAction.getHeaders()) {
 				if ("Content-type".equalsIgnoreCase(header.getName())) {


### PR DESCRIPTION
See [JENKINS-66312](https://issues.jenkins.io/browse/JENKINS-66312) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.collect.Ranges` class, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/collect/Ranges.html) but has been removed in later versions.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. The general recommendation is to rewrite the code to avoid the use of the `Ranges` class. In this PR I am removing all usages of Guava from this plugin.

CC @meowlomoDevelopment